### PR TITLE
prevent insertOrUpdate method from modifying the passed data object

### DIFF
--- a/simplemysql/simplemysql.py
+++ b/simplemysql/simplemysql.py
@@ -147,10 +147,9 @@ class SimpleMysql:
 	def insertOrUpdate(self, table, data, keys):
 		insert_data = data.copy()
 
-		insert = self._serialize_insert(insert_data)
+		data = {k: data[k] for k in data if k not in keys}
 
-		for k in keys:
-			del data[k]
+		insert = self._serialize_insert(insert_data)
 
 		update = self._serialize_update(data)
 


### PR DESCRIPTION
As you can see, within the `insertOrUpdate` method, this bit of code will modify the passed 'data' object outside the scope of the method:

    for k in keys:
        del data[k]

I propose a more graceful way of dealing with generating a dict object that excludes table keys:

`data = {k: data[k] for k in data if k not in keys}`