### PR TITLE
Adding examples and cleaning up README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ book = db.getOne("books", ["name", "year"], ("id=1"))
 # get multiple rows based on a parametrized condition
 books = db.getAll("books",
 	["id", "name"],
-	("year > %s and price < 15", [year, 12.99])
+	("year > %s and price < %s", [year, 12.99])
 )
 ```
 
@@ -101,7 +101,7 @@ books = db.getAll("books",
 # get multiple rows based on a parametrized condition with an order and limit specified
 books = db.getAll("books",
 	["id", "name", "year"],
-	("year > %s and price < 15", [year, 12.99]),
+	("year > %s and price < %s", [year, 12.99]),
 	["year", "DESC"],	# ORDER BY year DESC
 	[0, 10]			# LIMIT 0, 10
 )

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Insert a new row, or update if there is a primary key conflict.
 
 ```python
 # insert a book with id 123. if it already exists, update values
-db.insert("books",
+db.insertOrUpdate("books",
 		{"id": 123, type": "paperback", "name": "Time Machine", "price": 5.55},
 		"id"
 )

--- a/README.md
+++ b/README.md
@@ -90,11 +90,6 @@ book = db.getOne("books", ["name", "year"], ("id=1"))
 ```
 
 ```python
-# get a row based on a simple hardcoded condition
-book = db.getOne("books", ["name", "year"], ("id=1"))
-```
-
-```python
 # get multiple rows based on a parametrized condition
 books = db.getAll("books",
 	["id", "name"],

--- a/README.md
+++ b/README.md
@@ -132,3 +132,8 @@ db.query("DELETE FROM books WHERE year > 2005")
 
 # commit()
 Insert, update, and delete operations on transactional databases such as innoDB need to be committed
+
+```python
+db.commit()
+```
+


### PR DESCRIPTION
The current state of README.md documents the functionality of insertOrUpdate(), but uses the incorrect function name.

The example snippet for getOne() was duplicated, the extra snippet was removed.

Added example snippet for commit() to maintain consistent style.

The query strings for the getAll() snippets were missing a substitution. Replaced the hardcoded price value in the querys with %s to correctly demonstrate passing parameters.