### PR TITLE
Python3 Update and more patches

### DIFF
--- a/simplemysql/simplemysql.py
+++ b/simplemysql/simplemysql.py
@@ -2,315 +2,313 @@
 # vim: fileencoding=utf-8: noexpandtab
 
 """
-	A very simple wrapper for MySQLdb
+    A very simple wrapper for mysql (mysql-connector)
 
-	Methods:
-		getOne() - get a single row
-		getAll() - get all rows
-		lastId() - get the last insert id
-		lastQuery() - get the last executed query
-		insert() - insert a row
-		insertBatch() - Batch Insert
-		insertOrUpdate() - insert a row or update it if it exists
-		update() - update rows
-		delete() - delete rows
-		query()  - run a raw sql query
-		leftJoin() - do an inner left join query and get results
+    Methods:
+        getOne() - get a single row
+        getAll() - get all rows
+        lastId() - get the last insert id
+        lastQuery() - get the last executed query
+        insert() - insert a row
+        insertBatch() - Batch Insert
+        insertOrUpdate() - insert a row or update it if it exists
+        update() - update rows
+        delete() - delete rows
+        query()  - run a raw sql query
+        leftJoin() - do an inner left join query and get results
 
-	License: GNU GPLv2
+    License: GNU GPLv2
 
-	Kailash Nadh, http://nadh.in
-	May 2013
+    Kailash Nadh, http://nadh.in
+    May 2013
+
+    Updated by: Milosh Bolic
+    June 2019
 """
 
-import MySQLdb
+import mysql.connector as mysql
 from collections import namedtuple
 from itertools import repeat
 
 
 class SimpleMysql:
-	conn = None
-	cur = None
-	conf = None
-
-	def __init__(self, **kwargs):
-		self.conf = kwargs
-		self.conf["keep_alive"] = kwargs.get("keep_alive", False)
-		self.conf["charset"] = kwargs.get("charset", "utf8")
-		self.conf["host"] = kwargs.get("host", "localhost")
-		self.conf["port"] = kwargs.get("port", 3306)
-		self.conf["autocommit"] = kwargs.get("autocommit", False)
-		self.conf["ssl"] = kwargs.get("ssl", False)
-		self.connect()
-
-	def connect(self):
-		"""Connect to the mysql server"""
-
-		try:
-			if not self.conf["ssl"]:
-			    self.conn = MySQLdb.connect(db=self.conf['db'], host=self.conf['host'],
-										port=self.conf['port'], user=self.conf['user'],
-										passwd=self.conf['passwd'],
-										charset=self.conf['charset'])
-			else:
-			    self.conn = MySQLdb.connect(db=self.conf['db'], host=self.conf['host'],
-										port=self.conf['port'], user=self.conf['user'],
-										passwd=self.conf['passwd'],
-										ssl=self.conf['ssl'],
-										charset=self.conf['charset'])
-			self.cur = self.conn.cursor()
-			self.conn.autocommit(self.conf["autocommit"])
-		except:
-			print ("MySQL connection failed")
-			raise
-
-
-	def getOne(self, table=None, fields='*', where=None, order=None, limit=(0, 1)):
-		"""Get a single result
-
-			table = (str) table_name
-			fields = (field1, field2 ...) list of fields to select
-			where = ("parameterizedstatement", [parameters])
-					eg: ("id=%s and name=%s", [1, "test"])
-			order = [field, ASC|DESC]
-			limit = [limit1, limit2]
-		"""
-
-		cur = self._select(table, fields, where, order, limit)
-		result = cur.fetchone()
+    conn = None
+    cur = None
+    conf = None
+
+    def __init__(self, **kwargs):
+        self.conf = kwargs
+        self.conf["keep_alive"] = kwargs.get("keep_alive", False)
+        self.conf["charset"] = kwargs.get("charset", "utf8")
+        self.conf["host"] = kwargs.get("host", "localhost")
+        self.conf["port"] = kwargs.get("port", 3306)
+        self.conf["autocommit"] = kwargs.get("autocommit", False)
+        self.conf["ssl"] = kwargs.get("ssl", False)
+        self.connect()
+
+    def connect(self):
+        """Connect to the mysql server"""
+
+        try:
+            if not self.conf["ssl"]:
+                self.conn = mysql.connect(db=self.conf['db'], host=self.conf['host'],
+                                          port=self.conf['port'], user=self.conf['user'],
+                                          passwd=self.conf['passwd'],
+                                          charset=self.conf['charset'])
+            else:
+                self.conn = mysql.connect(db=self.conf['db'], host=self.conf['host'],
+                                          port=self.conf['port'], user=self.conf['user'],
+                                          passwd=self.conf['passwd'],
+                                          ssl=self.conf['ssl'],
+                                          charset=self.conf['charset'])
+            self.cur = self.conn.cursor()
+            self.conn.autocommit = self.conf["autocommit"]
+        except:
+            print("MySQL connection failed")
+            raise
+
+    def getOne(self, table=None, fields='*', where=None, order=None, limit=(0, 1)):
+        """Get a single result
+
+            table = (str) table_name
+            fields = (field1, field2 ...) list of fields to select
+            where = ("parameterizedstatement", [parameters])
+                    eg: ("id=%s and name=%s", [1, "test"])
+            order = [field, ASC|DESC]
+            limit = [from, to]
+        """
+
+        cur = self._select(table, fields, where, order, limit)
+        result = cur.fetchone()
+
+        row = None
+        if result:
+            fields = [f[0] for f in cur.description]
+            row = zip(fields, result)
+
+        return dict(row)
+
+    def getAll(self, table=None, fields='*', where=None, order=None, limit=None):
+        """Get all results
 
-		row = None
-		if result:
-			Row = namedtuple("Row", [f[0] for f in cur.description])
-			row = Row(*result)
+            table = (str) table_name
+            fields = (field1, field2 ...) list of fields to select
+            where = ("parameterizedstatement", [parameters])
+                    eg: ("id=%s and name=%s", [1, "test"])
+            order = [field, ASC|DESC]
+            limit = [from, to]
+        """
 
-		return row
+        cur = self._select(table, fields, where, order, limit)
+        result = cur.fetchall()
 
+        rows = None
+        if result:
+            fields = [f[0] for f in cur.description]
+            rows = [dict(zip(fields, r)) for r in result]
+
+        return rows
+
+    def lastId(self):
+        """Get the last insert id"""
+        return self.cur.lastrowid
+
+    def lastQuery(self):
+        """Get the last executed query"""
+        try:
+            return self.cur.statement
+        except AttributeError:
+            return self.cur._last_executed
+
+    def leftJoin(self, tables=(), fields=(), join_fields=(), where=None, order=None, limit=None):
+        """Run an inner left join query
+
+            tables = (table1, table2)
+            fields = ([fields from table1], [fields from table 2])  # fields to select
+            join_fields = (field1, field2)  # fields to join. field1 belongs to table1 and field2 belongs to table 2
+            where = ("parameterizedstatement", [parameters])
+                    eg: ("id=%s and name=%s", [1, "test"])
+            order = [field, ASC|DESC]
+            limit = [limit1, limit2]
+        """
+
+        cur = self._select_join(tables, fields, join_fields, where, order, limit)
+        result = cur.fetchall()
 
-	def getAll(self, table=None, fields='*', where=None, order=None, limit=None):
-		"""Get all results
+        rows = None
+        if result:
+            Row = namedtuple("Row", [f[0] for f in cur.description])
+            rows = [Row(*r) for r in result]
 
-			table = (str) table_name
-			fields = (field1, field2 ...) list of fields to select
-			where = ("parameterizedstatement", [parameters])
-					eg: ("id=%s and name=%s", [1, "test"])
-			order = [field, ASC|DESC]
-			limit = [limit1, limit2]
-		"""
+        return rows
 
-		cur = self._select(table, fields, where, order, limit)
-		result = cur.fetchall()
+    def insert(self, table, data):
+        """Insert a record"""
 
-		rows = None
-		if result:
-			Row = namedtuple("Row", [f[0] for f in cur.description])
-			rows = [Row(*r) for r in result]
+        query = self._serialize_insert(data)
 
-		return rows
+        sql = "INSERT INTO %s (%s) VALUES(%s)" % (table, query[0], query[1])
 
-	def lastId(self):
-		"""Get the last insert id"""
-		return self.cur.lastrowid
+        return self.query(sql, data.values()).rowcount
 
-	def lastQuery(self):
-		"""Get the last executed query"""
-		try:
-			return self.cur.statement
-		except AttributeError:
-			return self.cur._last_executed
+    def insertBatch(self, table, data):
+        """Insert multiple record"""
 
-	def leftJoin(self, tables=(), fields=(), join_fields=(), where=None, order=None, limit=None):
-		"""Run an inner left join query
+        query = self._serialize_batch_insert(data)
+        sql = "INSERT INTO %s (%s) VALUES %s" % (table, query[0], query[1])
+        flattened_values = [v for sublist in data for k, v in sublist.iteritems()]
+        return self.query(sql, flattened_values).rowcount
 
-			tables = (table1, table2)
-			fields = ([fields from table1], [fields from table 2])  # fields to select
-			join_fields = (field1, field2)  # fields to join. field1 belongs to table1 and field2 belongs to table 2
-			where = ("parameterizedstatement", [parameters])
-					eg: ("id=%s and name=%s", [1, "test"])
-			order = [field, ASC|DESC]
-			limit = [limit1, limit2]
-		"""
+    def update(self, table, data, where=None):
+        """Insert a record"""
 
-		cur = self._select_join(tables, fields, join_fields, where, order, limit)
-		result = cur.fetchall()
+        query = self._serialize_update(data)
 
-		rows = None
-		if result:
-			Row = namedtuple("Row", [f[0] for f in cur.description])
-			rows = [Row(*r) for r in result]
+        sql = "UPDATE %s SET %s" % (table, query)
 
-		return rows
+        if where and len(where) > 0:
+            sql += " WHERE %s" % where[0]
 
+        return self.query(sql, data.values() + where[1] if where and len(where) > 1 else data.values()
+                          ).rowcount
 
-	def insert(self, table, data):
-		"""Insert a record"""
+    def insertOrUpdate(self, table, data, keys):
+        insert_data = data.copy()
 
-		query = self._serialize_insert(data)
+        data = {k: data[k] for k in data if k not in keys}
 
-		sql = "INSERT INTO %s (%s) VALUES(%s)" % (table, query[0], query[1])
+        insert = self._serialize_insert(insert_data)
 
-		return self.query(sql, data.values()).rowcount
+        update = self._serialize_update(data)
 
-	def insertBatch(self, table, data):
-		"""Insert multiple record"""
+        sql = "INSERT INTO %s (%s) VALUES(%s) ON DUPLICATE KEY UPDATE %s" % (table, insert[0], insert[1], update)
 
-		query = self._serialize_batch_insert(data)
-		sql = "INSERT INTO %s (%s) VALUES %s" % (table, query[0], query[1])
-		flattened_values = [v for sublist in data for k,v in sublist.iteritems()]
-		return self.query(sql,flattened_values).rowcount
+        return self.query(sql, insert_data.values() + data.values()).rowcount
 
-	def update(self, table, data, where = None):
-		"""Insert a record"""
+    def delete(self, table, where=None):
+        """Delete rows based on a where condition"""
 
-		query = self._serialize_update(data)
+        sql = "DELETE FROM %s" % table
 
-		sql = "UPDATE %s SET %s" % (table, query)
+        if where and len(where) > 0:
+            sql += " WHERE %s" % where[0]
 
-		if where and len(where) > 0:
-			sql += " WHERE %s" % where[0]
+        return self.query(sql, where[1] if where and len(where) > 1 else None).rowcount
 
-		return self.query(sql, data.values() + where[1] if where and len(where) > 1 else data.values()
-						).rowcount
+    def query(self, sql, params=None):
+        """Run a raw query"""
 
+        # check if connection is alive. if not, reconnect
+        try:
+            self.cur.execute(sql, params)
+        except mysql.OperationalError as e:
+            # mysql timed out. reconnect and retry once
+            if e[0] == 2006:
+                self.connect()
+                self.cur.execute(sql, params)
+            else:
+                raise
+        except:
+            print("Query failed")
+            raise
 
-	def insertOrUpdate(self, table, data, keys):
-		insert_data = data.copy()
+        return self.cur
 
-		data = {k: data[k] for k in data if k not in keys}
+    def commit(self):
+        """Commit a transaction (transactional engines like InnoDB require this)"""
+        return self.conn.commit()
 
-		insert = self._serialize_insert(insert_data)
+    def is_open(self):
+        """Check if the connection is open"""
+        return self.conn.open
 
-		update = self._serialize_update(data)
+    def end(self):
+        """Kill the connection"""
+        self.cur.close()
+        self.conn.close()
 
-		sql = "INSERT INTO %s (%s) VALUES(%s) ON DUPLICATE KEY UPDATE %s" % (table, insert[0], insert[1], update)
+    # ===
 
-		return self.query(sql, insert_data.values() + data.values() ).rowcount
+    def _serialize_insert(self, data):
+        """Format insert dict values into strings"""
+        keys = ",".join(data.keys())
+        vals = ",".join(["%s" for k in data])
 
-	def delete(self, table, where = None):
-		"""Delete rows based on a where condition"""
+        return [keys, vals]
 
-		sql = "DELETE FROM %s" % table
+    def _serialize_batch_insert(self, data):
+        """Format insert dict values into strings"""
+        keys = ",".join(data[0].keys())
+        v = "(%s)" % ",".join(tuple("%s".rstrip(',') for v in range(len(data[0]))))
+        l = ','.join(list(repeat(v, len(data))))
+        return [keys, l]
 
-		if where and len(where) > 0:
-			sql += " WHERE %s" % where[0]
+    def _serialize_update(self, data):
+        """Format update dict values into string"""
+        return "=%s,".join(data.keys()) + "=%s"
 
-		return self.query(sql, where[1] if where and len(where) > 1 else None).rowcount
+    def _select(self, table=None, fields=(), where=None, order=None, limit=None):
+        """Run a select query"""
 
+        sql = "SELECT %s FROM `%s`" % (",".join(fields), table)
 
-	def query(self, sql, params = None):
-		"""Run a raw query"""
+        # where conditions
+        if where and len(where) > 0:
+            sql += " WHERE %s" % where[0]
 
-		# check if connection is alive. if not, reconnect
-		try:
-			self.cur.execute(sql, params)
-		except MySQLdb.OperationalError, e:
-			# mysql timed out. reconnect and retry once
-			if e[0] == 2006:
-				self.connect()
-				self.cur.execute(sql, params)
-			else:
-				raise
-		except:
-			print("Query failed")
-			raise
+        # order
+        if order:
+            sql += " ORDER BY %s" % order[0]
 
-		return self.cur
+            if len(order) > 1:
+                sql += " %s" % order[1]
 
-	def commit(self):
-		"""Commit a transaction (transactional engines like InnoDB require this)"""
-		return self.conn.commit()
+        # limit
+        if limit:
+            sql += " LIMIT %s" % limit[0]
 
-	def is_open(self):
-		"""Check if the connection is open"""
-		return self.conn.open
+            if len(limit) > 1:
+                sql += ", %s" % limit[1]
 
-	def end(self):
-		"""Kill the connection"""
-		self.cur.close()
-		self.conn.close()
+        print(sql)
+        return self.query(sql, where[1] if where and len(where) > 1 else None)
 
-	# ===
+    def _select_join(self, tables=(), fields=(), join_fields=(), where=None, order=None, limit=None):
+        """Run an inner left join query"""
 
-	def _serialize_insert(self, data):
-		"""Format insert dict values into strings"""
-		keys = ",".join( data.keys() )
-		vals = ",".join(["%s" for k in data])
+        fields = [tables[0] + "." + f for f in fields[0]] + \
+                 [tables[1] + "." + f for f in fields[1]]
 
-		return [keys, vals]
+        sql = "SELECT %s FROM %s LEFT JOIN %s ON (%s = %s)" % \
+              (",".join(fields),
+               tables[0],
+               tables[1],
+               tables[0] + "." + join_fields[0],
+               tables[1] + "." + join_fields[1]
+               )
 
-	def _serialize_batch_insert(self, data):
-		"""Format insert dict values into strings"""
-		keys = ",".join( data[0].keys() )
-		v = "(%s)" % ",".join(tuple("%s".rstrip(',') for v in range(len(data[0]))))
-		l = ','.join(list(repeat(v,len(data))))
-		return [keys, l]
+        # where conditions
+        if where and len(where) > 0:
+            sql += " WHERE %s" % where[0]
 
-	def _serialize_update(self, data):
-		"""Format update dict values into string"""
-		return "=%s,".join( data.keys() ) + "=%s"
+        # order
+        if order:
+            sql += " ORDER BY %s" % order[0]
 
+            if len(order) > 1:
+                sql += " " + order[1]
 
-	def _select(self, table=None, fields=(), where=None, order=None, limit=None):
-		"""Run a select query"""
+        # limit
+        if limit:
+            sql += " LIMIT %s" % limit[0]
 
-		sql = "SELECT %s FROM `%s`" % (",".join(fields), table)
+            if len(limit) > 1:
+                sql += ", %s" % limit[1]
 
-		# where conditions
-		if where and len(where) > 0:
-			sql += " WHERE %s" % where[0]
+        return self.query(sql, where[1] if where and len(where) > 1 else None)
 
-		# order
-		if order:
-			sql += " ORDER BY %s" % order[0]
+    def __enter__(self):
+        return self
 
-			if len(order) > 1:
-				sql+= " %s" % order[1]
-
-		# limit
-		if limit:
-			sql += " LIMIT %s" % limit[0]
-
-			if len(limit) > 1:
-				sql+= ", %s" % limit[1]
-
-		return self.query(sql, where[1] if where and len(where) > 1 else None)
-
-	def _select_join(self, tables=(), fields=(), join_fields=(), where=None, order=None, limit=None):
-		"""Run an inner left join query"""
-
-		fields = [tables[0] + "." + f for f in fields[0]] + \
-				 [tables[1] + "." + f for f in fields[1]]
-
-		sql = "SELECT %s FROM %s LEFT JOIN %s ON (%s = %s)" % \
-				( 	",".join(fields),
-					tables[0],
-					tables[1],
-					tables[0] + "." + join_fields[0], \
-					tables[1] + "." + join_fields[1]
-				)
-
-		# where conditions
-		if where and len(where) > 0:
-			sql += " WHERE %s" % where[0]
-
-		# order
-		if order:
-			sql += " ORDER BY %s" % order[0]
-
-			if len(order) > 1:
-				sql+= " " + order[1]
-
-		# limit
-		if limit:
-			sql += " LIMIT %s" % limit[0]
-
-			if len(limit) > 1:
-				sql+= ", %s" % limit[1]
-
-		return self.query(sql, where[1] if where and len(where) > 1 else None)
-
-	def __enter__(self):
-		return self
-
-	def __exit__(self, type, value, traceback):
-		self.end()
+    def __exit__(self, type, value, traceback):
+        self.end()

--- a/simplemysql/simplemysql.py
+++ b/simplemysql/simplemysql.py
@@ -270,7 +270,6 @@ class SimpleMysql:
             if len(limit) > 1:
                 sql += ", %s" % limit[1]
 
-        print(sql)
         return self.query(sql, where[1] if where and len(where) > 1 else None)
 
     def _select_join(self, tables=(), fields=(), join_fields=(), where=None, order=None, limit=None):


### PR DESCRIPTION
- Move from MySQLdb to mysql.connector
- Upgrade code to python3
- Replace `namedtuple` with dict as data frame 
Explanation about this replace:
I run into trouble using `namedtuple` while working on the table which has a column name `class`: 
```
raise ValueError('Type names and field names cannot be a '
ValueError: Type names and field names cannot be a keyword: 'class'
```



